### PR TITLE
Fix typedef pluginapi_create_t.

### DIFF
--- a/AppPlugins/AfterEffectsPlugin/AfterEffectsPlugin.h
+++ b/AppPlugins/AfterEffectsPlugin/AfterEffectsPlugin.h
@@ -10,8 +10,6 @@
 #include "AEGP_SuiteHandler.h"
 #include "../../VoukoderPro/voukoderpro_api.h"
 
-typedef std::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 #define ARB_VERSION 1
 
 #ifdef __cplusplus

--- a/AppPlugins/DaVinciResolvePlugin/plugin.cpp
+++ b/AppPlugins/DaVinciResolvePlugin/plugin.cpp
@@ -51,7 +51,7 @@ StatusCode g_HandleCreateObj(unsigned char* p_pUUID, ObjectRef* p_ppObj)
 StatusCode g_HandlePluginStart()
 {
     boost::function<pluginapi_create_t> factory;
-    boost::shared_ptr<VoukoderPro::IClient> vkdrpro;
+    std::shared_ptr<VoukoderPro::IClient> vkdrpro;
 
     try
     {

--- a/AppPlugins/DaVinciResolvePlugin/video_encoder.cpp
+++ b/AppPlugins/DaVinciResolvePlugin/video_encoder.cpp
@@ -51,7 +51,7 @@ public:
         if (val8 != 0)
         {
             boost::function<pluginapi_create_t> factory;
-            boost::shared_ptr<VoukoderPro::IClient> vkdrpro;
+            std::shared_ptr<VoukoderPro::IClient> vkdrpro;
 
             try
             {
@@ -115,7 +115,7 @@ private:
     StatusCode RenderGeneral(HostListRef* p_pSettingsList)
     {
         boost::function<pluginapi_create_t> factory;
-        boost::shared_ptr<VoukoderPro::IClient> vkdrpro;
+        std::shared_ptr<VoukoderPro::IClient> vkdrpro;
 
         try
         {

--- a/AppPlugins/DaVinciResolvePlugin/video_encoder.h
+++ b/AppPlugins/DaVinciResolvePlugin/video_encoder.h
@@ -9,8 +9,6 @@
 
 using namespace IOPlugin;
 
-typedef boost::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 class UISettingsController;
 
 static inline int hash(const char* str)

--- a/AppPlugins/DaVinciResolvePlugin/voukoderpro.hpp
+++ b/AppPlugins/DaVinciResolvePlugin/voukoderpro.hpp
@@ -15,8 +15,6 @@ using json = nlohmann::json;
 
 #include "..\..\VoukoderPro\VoukoderPro_API.h"
 
-typedef boost::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 class VoukoderBase
 {
 public:
@@ -78,5 +76,5 @@ public:
 
 protected:
     boost::function<pluginapi_create_t> factory;
-    boost::shared_ptr<VoukoderPro::IClient> vkdrpro = nullptr;
+    std::shared_ptr<VoukoderPro::IClient> vkdrpro = nullptr;
 };

--- a/AppPlugins/PremiereCCPlugin/plugin.h
+++ b/AppPlugins/PremiereCCPlugin/plugin.h
@@ -10,8 +10,6 @@
 
 #include "../../VoukoderPro/voukoderpro_api.h"
 
-typedef std::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 #define ALIGN16(value) (((value + 15) >> 4) << 4)
 #define ALIGN32(X) (((mfxU32)((X) + 31)) & (~(mfxU32)31))
 

--- a/Designer/components/Test/scenetestdialog.cpp
+++ b/Designer/components/Test/scenetestdialog.cpp
@@ -3,8 +3,6 @@
 
 #include "boost/dll/import.hpp"
 
-typedef std::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 Worker::Worker(std::shared_ptr<VoukoderPro::SceneInfo> sceneInfo, VoukoderPro::config project, const int iterations):
     sceneInfo(sceneInfo), project(project), iterations(iterations)
 {}

--- a/Designer/mainwindow.h
+++ b/Designer/mainwindow.h
@@ -10,8 +10,6 @@
 #include "preferences.h"
 #include "newsdialog.h"
 
-typedef std::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
-
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE

--- a/VoukoderPro/voukoderpro_api.h
+++ b/VoukoderPro/voukoderpro_api.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#ifndef VP_API
+#define VP_API
+
 #include "../VoukoderPro/types.h"
 #include "../PluginInterface/properties.h"
 
 #include <boost/date_time/gregorian/gregorian.hpp>
+#include "boost/function.hpp"
+#include "boost/dll.hpp"
 
 #ifdef _DEBUG
 #define VOUKODERPRO_HOME \
@@ -70,3 +75,7 @@ namespace VoukoderPro
         //virtual std::shared_ptr<IPerformanceManager> performanceManager() = 0;
     };
 }
+
+typedef std::shared_ptr<VoukoderPro::IClient>(pluginapi_create_t)();
+
+#endif


### PR DESCRIPTION
typedef of pluginapi_create_t is inconsistent between files, some is boost::shared_ptr while others are std::shared_ptr
fix it, while also, moving the typedef to voukoderpro_api.h,
change them all to std::shared_ptr