### PR TITLE
Improvements on the macros in voukoderpro_api.h

### DIFF
--- a/AppPlugins/AfterEffectsPlugin/AfterEffectsPlugin.cpp
+++ b/AppPlugins/AfterEffectsPlugin/AfterEffectsPlugin.cpp
@@ -10,7 +10,7 @@
 #include <boost/function.hpp>
 #include <boost/dll.hpp>
 
-extern boost::function<pluginapi_create_t> factory = VOUKODERPRO_CREATE_INSTANCE;
+boost::function<pluginapi_create_t> factory = VoukoderProCreateInstance();
 static std::shared_ptr<VoukoderPro::IClient> vkdrpro = NULL;
 
 AEGP_PluginID S_mem_id = 0;

--- a/AppPlugins/DaVinciResolvePlugin/plugin.cpp
+++ b/AppPlugins/DaVinciResolvePlugin/plugin.cpp
@@ -55,7 +55,7 @@ StatusCode g_HandlePluginStart()
 
     try
     {
-        factory = VOUKODERPRO_CREATE_INSTANCE;
+        factory = VoukoderProCreateInstance();
         vkdrpro = factory();
 
         if (!vkdrpro)

--- a/AppPlugins/DaVinciResolvePlugin/video_encoder.cpp
+++ b/AppPlugins/DaVinciResolvePlugin/video_encoder.cpp
@@ -55,7 +55,7 @@ public:
 
             try
             {
-                factory = VOUKODERPRO_CREATE_INSTANCE;
+                factory = VoukoderProCreateInstance();
                 vkdrpro = factory();
 
                 if (!vkdrpro)
@@ -119,7 +119,7 @@ private:
 
         try
         {
-            factory = VOUKODERPRO_CREATE_INSTANCE;
+            factory = VoukoderProCreateInstance();
             vkdrpro = factory();
 
             if (!vkdrpro)

--- a/AppPlugins/DaVinciResolvePlugin/voukoderpro.hpp
+++ b/AppPlugins/DaVinciResolvePlugin/voukoderpro.hpp
@@ -28,7 +28,7 @@ public:
         try
         {
             // Create voukoderpro class factory
-            factory = VOUKODERPRO_CREATE_INSTANCE;
+            factory = VoukoderProCreateInstance();
 
             // Create an instance
             vkdrpro = factory();

--- a/AppPlugins/PremiereCCPlugin/plugin.cpp
+++ b/AppPlugins/PremiereCCPlugin/plugin.cpp
@@ -8,7 +8,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/dll.hpp>
 
-extern boost::function<pluginapi_create_t> factory = VOUKODERPRO_CREATE_INSTANCE;
+boost::function<pluginapi_create_t> factory = VoukoderProCreateInstance();
 
 static inline int hash(const char* str)
 {

--- a/Designer/components/Test/scenetestdialog.cpp
+++ b/Designer/components/Test/scenetestdialog.cpp
@@ -10,7 +10,7 @@ Worker::Worker(std::shared_ptr<VoukoderPro::SceneInfo> sceneInfo, VoukoderPro::c
 void Worker::run()
 {
     // Create voukoderpro class factory
-    auto factory = VOUKODERPRO_CREATE_INSTANCE;
+    auto factory = VoukoderProCreateInstance();
     auto vkdrpro = factory();
     if (!vkdrpro)
         return;

--- a/Designer/main.cpp
+++ b/Designer/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
     try
     {
-        factory = VOUKODERPRO_CREATE_INSTANCE;
+        factory = VoukoderProCreateInstance();
         vkdrPro = factory();
     }
     catch (boost::system::system_error e)

--- a/Designer/preferences.cpp
+++ b/Designer/preferences.cpp
@@ -6,7 +6,7 @@
 #include "../VoukoderPro/voukoderpro_api.h"
 
 Preferences::Preferences():
-    filename((VOUKODERPRO_DATA / "preferences.json").string())
+    filename((VoukoderProData() / "preferences.json").string())
 {
     // Provide a default configuration
     data[nlohmann::ordered_json::json_pointer(VPRO_GENERAL_OPEN_SCENE)] = "simple";

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -11,7 +11,7 @@ int main()
 
     try
     {
-        factory = VOUKODERPRO_CREATE_INSTANCE;
+        factory = VoukoderProCreateInstance();
         vkdrpro = factory();
 
         if (!vkdrpro)

--- a/VoukoderPro/SceneManager.cpp
+++ b/VoukoderPro/SceneManager.cpp
@@ -103,7 +103,7 @@ namespace VoukoderPro
 	}
 
 	SceneManager::SceneManager():
-		sceneFile(fs::path(VOUKODERPRO_DATA) / "scenes.json")
+		sceneFile(fs::path(VoukoderProData()) / "scenes.json")
 	{}
 
 	int SceneManager::load(std::vector<std::shared_ptr<SceneInfo>>& sceneInfos)

--- a/VoukoderPro/voukoderpro.cpp
+++ b/VoukoderPro/voukoderpro.cpp
@@ -25,7 +25,7 @@ namespace VoukoderPro
 	static std::string logbuffer;
 
 	Client::Client() :
-		homeDir(VOUKODERPRO_HOME), dataDir(VOUKODERPRO_DATA), sceneInfo({})
+		homeDir(VOUKODERPRO_HOME), dataDir(VoukoderProData()), sceneInfo({})
 	{
 		// Make sure all dirs exists where data should be stored
 		if (!boost::filesystem::is_directory(dataDir))
@@ -567,7 +567,7 @@ namespace VoukoderPro
 		// Logging
 		logging::add_common_attributes();
 
-        fs::path dataDir(VOUKODERPRO_DATA);
+        fs::path dataDir(VoukoderProData());
 
 		logging::add_file_log(
             boost::log::keywords::file_name = (dataDir / "logs" / "voukoderpro-%N.log").c_str(),

--- a/VoukoderPro/voukoderpro_api.h
+++ b/VoukoderPro/voukoderpro_api.h
@@ -6,7 +6,6 @@
 #include "../VoukoderPro/types.h"
 #include "../PluginInterface/properties.h"
 
-#include "QStandardPaths"
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include "boost/function.hpp"
 #include "boost/dll.hpp"
@@ -18,10 +17,6 @@
 #define VOUKODERPRO_HOME \
     []()->std::string { const char* c = std::getenv("VOUKODERPRO_HOME"); return c ? std::string(c) : ""; }()
 #endif
-
-#define VOUKODERPRO_DATA \
-    boost::filesystem::path(QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation)[0].toStdString()) / "VoukoderPro"
-
 
 namespace VoukoderPro
 {
@@ -85,4 +80,23 @@ inline boost::function<pluginapi_create_t> VoukoderProCreateInstance(){
     return boost::dll::import_alias<pluginapi_create_t>(dllName,"createInstance", boost::dll::load_mode::append_decorations | boost::dll::load_mode::search_system_folders);
 }
 
+#ifdef __WIN32
+inline boost::filesystem::path VoukoderProData(){
+    return boost::filesystem::path(std::getenv("LOCALAPPDATA")) / "VoukoderPro";
+}
+#else
+
+inline boost::filesystem::path VoukoderProData() {
+    std::string xdgDataHome(std::getenv("XDG_DATA_HOME"));
+    boost::filesystem::path dataDir;
+    if (xdgDataHome.empty()) {
+        boost::filesystem::path home(std::getenv("HOME"));
+        dataDir = home / ".local" / "share";
+    } else {
+        dataDir = boost::filesystem::path(xdgDataHome);
+    }
+    return dataDir / "VoukoderPro";
+}
+
 #endif
+#endif // VP_API


### PR DESCRIPTION
Improve the definition of VOUKODERPRO_DATA, using QStandardPaths, it still returns "C:/Users/\<USER>/AppData/Local" on Windows, and also works on other platforms.
make VOUKODERPRO_CREATE_INSTANCE an inline function so it's easier to read, also search the dynamic library in system paths.

NOTE: Now everything uses voukoderpro_api.h has to link with QtCore, I suppose, @Vouk, please check this and add QtCore to the libraries list before approving this PR. I can't do this, I don't know how to deal with the `vcxproj` file.