### PR TITLE
Add a CMake file for Designer.

### DIFF
--- a/Designer/BUILDING
+++ b/Designer/BUILDING
@@ -1,0 +1,4 @@
+mkdir <build-dir>
+cd ./<build-dir>
+cmake ..
+cmake --build . -t VoukoderDesigner

--- a/Designer/CMakeLists.txt
+++ b/Designer/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(PropertyBrowser PRIVATE Qt6::Core Qt6::Widgets)
 FetchContent_Declare(
         NodeEditor2
         GIT_REPOSITORY https://github.com/RealXuChe/nodeeditor.git
-        GIT_TAG 2.2.5
+        GIT_TAG 2.2.6
 #        PATCH_COMMAND ${PatchNE2Cmake}
         EXCLUDE_FROM_ALL
 )

--- a/Designer/CMakeLists.txt
+++ b/Designer/CMakeLists.txt
@@ -1,0 +1,136 @@
+cmake_minimum_required(VERSION 3.28)
+
+if(onGitHubActions)
+    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../vcpkg/scripts/buildsystems/vcpkg.cmake")
+    set(VCPKG_INSTALL_OPTIONS "--x-buildtrees-root=D:/v/")
+endif ()
+
+project(VoukoderDesigner LANGUAGES CXX)
+
+include(FetchContent)
+
+set(CMAKE_CXX_STANDARD 23)
+
+find_package(Boost REQUIRED COMPONENTS filesystem)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui Network UiTools)
+
+qt_standard_project_setup()
+
+# Qt Property Browser
+# TODO: make qttools version as a variable
+FetchContent_Declare(
+        QtTools
+        URL https://download.qt.io/official_releases/qt/6.6/6.6.1/submodules/qttools-everywhere-src-6.6.1.tar.xz
+)
+FetchContent_GetProperties(QtTools)
+if(NOT qttools_POPULATED)
+    FetchContent_Populate(QtTools)
+endif()
+
+add_compile_definitions(CMAKE_PROPERTY_BROWSER)
+
+set(PropertyBrowser_SRC
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtbuttonpropertybrowser.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qteditorfactory.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtgroupboxpropertybrowser.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtpropertybrowser.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtpropertybrowserutils.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtpropertymanager.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qttreepropertybrowser.cpp
+        ${qttools_SOURCE_DIR}/src/shared/qtpropertybrowser/qtvariantproperty.cpp)
+
+qt_add_library(PropertyBrowser
+        STATIC
+        ${PropertyBrowser_SRC}
+)
+
+target_link_libraries(PropertyBrowser PRIVATE Qt6::Core Qt6::Widgets)
+
+# Node Editor 2
+#set(PatchNE2Cmake git apply ${CMAKE_CURRENT_SOURCE_DIR}/BuildNodeEditor2.patch)
+FetchContent_Declare(
+        NodeEditor2
+        GIT_REPOSITORY https://github.com/RealXuChe/nodeeditor.git
+        GIT_TAG 2.2.5
+#        PATCH_COMMAND ${PatchNE2Cmake}
+        EXCLUDE_FROM_ALL
+)
+FUNCTION( NE2_MakeAvailable )
+    set(BUILD_TESTING OFF)
+    set(BUILD_EXAMPLES OFF)
+    set(BUILD_SHARED_LIBS OFF)
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+    FetchContent_MakeAvailable(NodeEditor2)
+ENDFUNCTION ()
+NE2_MakeAvailable()
+
+# Voukoder Designer
+set(SRCS
+        aboutdialog.cpp
+        components/SceneEditor/nodes/sceneeditorencodernodemodel.cpp
+        components/SceneEditor/nodes/sceneeditorfilternodemodel.cpp
+        components/SceneEditor/nodes/sceneeditorinputnodemodel.cpp
+        components/SceneEditor/nodes/sceneeditormuxernodemodel.cpp
+        components/SceneEditor/nodes/sceneeditornodemodel.cpp
+        components/SceneEditor/nodes/sceneeditoroutputnodemodel.cpp
+        components/SceneEditor/nodes/sceneeditorpostprocnodemodel.cpp
+        components/SceneEditor/nodes/ui/encoderpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/filterpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/inputpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/muxerpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/outputpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/postprocpropertiesdialog.cpp
+        components/SceneEditor/nodes/ui/propertiesdialog.cpp
+        components/SceneEditor/sceneeditorscene.cpp
+        components/SceneEditor/sceneeditorview.cpp
+        main.cpp
+        mainwindow.cpp
+        newsdialog.cpp
+        preferences.cpp
+        preferencesdialog.cpp
+        sceneopendialog.cpp
+        scenesavedialog.cpp
+        sceneselectdialog.cpp
+        supportdialog.cpp
+        components/Test/scenetestdialog.cpp
+        components/Test/performancetestdialog.cpp
+        components/Test/addeditaudiotrackdialog.cpp
+        components/Test/addeditvideotrackdialog.cpp
+)
+
+set(FORMS
+        aboutdialog.ui
+        components/SceneEditor/nodes/ui/inputpropertiesdialog.ui
+        components/SceneEditor/nodes/ui/propertiesdialog.ui
+        mainwindow.ui
+        newsdialog.ui
+        preferencesdialog.ui
+        sceneopendialog.ui
+        scenesavedialog.ui
+        sceneselectdialog.ui
+        supportdialog.ui
+        components/Test/scenetestdialog.ui
+        components/Test/performancetestdialog.ui
+        components/Test/addeditvideotrackdialog.ui
+        components/Test/addeditaudiotrackdialog.ui
+)
+
+qt_add_executable(VoukoderDesigner
+        ${SRCS}
+        ${FORMS}
+        designer.qrc
+        fugue.qrc
+)
+
+#target_compile_definitions(VoukoderDesigner PRIVATE -DNODE_EDITOR_STATIC)
+
+target_include_directories(VoukoderDesigner PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${qttools_SOURCE_DIR}/src/shared
+        ${Boost_INCLUDE_DIRS})
+
+target_link_libraries(VoukoderDesigner PRIVATE Qt6::Core Qt6::Gui Qt6::Network Qt6::Widgets Qt6::UiTools PropertyBrowser ${Boost_LIBRARIES} nodes)
+
+install(TARGETS VoukoderDesigner
+        RUNTIME DESTINATION usr/bin
+)

--- a/Designer/components/SceneEditor/nodes/sceneeditornodemodel.cpp
+++ b/Designer/components/SceneEditor/nodes/sceneeditornodemodel.cpp
@@ -3,8 +3,6 @@
 #include <boost/describe/enum_to_string.hpp>
 #include <QLabel>
 
-Q_DECLARE_METATYPE(VoukoderPro::AssetInfo)
-
 /**
  * @brief SceneEditorNodeModel::SceneEditorNodeModel
  * @param nodeInfo

--- a/Designer/components/SceneEditor/nodes/sceneeditornodemodel.h
+++ b/Designer/components/SceneEditor/nodes/sceneeditornodemodel.h
@@ -4,12 +4,18 @@
 #include <nodes/NodeData>
 
 #include "../VoukoderPro/voukoderpro_api.h"
+#include "designer_types.h"
 #include <QDialog>
 #include <QVBoxLayout>
 #include <QLabel>
 
+#ifdef CMAKE_PROPERTY_BROWSER
+#include "qtpropertybrowser/qttreepropertybrowser.h"
+#include "qtpropertybrowser/qtvariantproperty.h"
+#else
 #include "include/QtPropertyBrowser/qttreepropertybrowser.h"
 #include "include/QtPropertyBrowser/qtvariantproperty.h"
+#endif
 #include "sceneeditornodedata.h"
 
 #define TYPE_RAW_VIDEO "uncompressed_video"

--- a/Designer/components/SceneEditor/nodes/ui/propertiesdialog.h
+++ b/Designer/components/SceneEditor/nodes/ui/propertiesdialog.h
@@ -4,10 +4,13 @@
 #include <QAbstractButton>
 #include <QTreeWidgetItem>
 #include "../VoukoderPro/types.h"
+#ifdef CMAKE_PROPERTY_BROWSER
+#include "qtpropertybrowser/qtvariantproperty.h"
+#else
 #include "qtvariantproperty.h"
+#endif
 #include <json.hpp>
-
-Q_DECLARE_METATYPE(VoukoderPro::AssetInfo)
+#include "designer_types.h"
 
 namespace Ui {
 class PropertiesDialog;

--- a/Designer/components/SceneEditor/nodes/ui/propertiesdialog.ui
+++ b/Designer/components/SceneEditor/nodes/ui/propertiesdialog.ui
@@ -717,7 +717,7 @@
   <customwidget>
    <class>QtTreePropertyBrowser</class>
    <extends>QWidget</extends>
-   <header location="global">qttreepropertybrowser.h</header>
+   <header location="global">qtpropertybrowser/qttreepropertybrowser.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Designer/designer_types.h
+++ b/Designer/designer_types.h
@@ -1,0 +1,11 @@
+#ifndef DESIGNER_TYPES
+#define DESIGNER_TYPES
+#include "../VoukoderPro/voukoderpro_api.h"
+#include "qmetatype.h"
+
+Q_DECLARE_METATYPE(VoukoderPro::NodeInfo)
+Q_DECLARE_METATYPE(VoukoderPro::SceneInfo)
+Q_DECLARE_METATYPE(VoukoderPro::AssetInfo)
+Q_DECLARE_METATYPE(std::shared_ptr<VoukoderPro::SceneInfo>)
+
+#endif // DESIGNER_TYPES

--- a/Designer/mainwindow.h
+++ b/Designer/mainwindow.h
@@ -9,14 +9,11 @@
 #include "components/SceneEditor/sceneeditorview.h"
 #include "preferences.h"
 #include "newsdialog.h"
+#include "designer_types.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
-
-Q_DECLARE_METATYPE(VoukoderPro::NodeInfo)
-Q_DECLARE_METATYPE(VoukoderPro::SceneInfo)
-Q_DECLARE_METATYPE(VoukoderPro::AssetInfo)
 
 class MainWindow : public QMainWindow
 {

--- a/Designer/sceneopendialog.h
+++ b/Designer/sceneopendialog.h
@@ -5,8 +5,7 @@
 #include <QTreeWidgetItem>
 
 #include "../VoukoderPro/voukoderpro_api.h"
-
-Q_DECLARE_METATYPE(std::shared_ptr<VoukoderPro::SceneInfo>)
+#include "designer_types.h"
 
 namespace Ui {
 class SceneOpenDialog;


### PR DESCRIPTION
![image](https://github.com/VoukoderPro/VoukoderPro/assets/47659370/3c91fcc3-a5b4-4078-a011-3ce8c818b97e)

I tested it, it builds on Windows in Qt Creator. If you want to build it using Qt Creator, you can't use the toolchain shipped with Qt Creator. You have to use the MinGW64 toolchain from msys to build it. I'll later write a guide for setting it up.

This PR breaks the existing sln project. To be exact, I changed the include file path in file `propertiesdialog.ui`, this will cause issues with the sln project.

Also, I collected all `Q_DECLARE_METATYPE` into a single header, to avoid some symbol-redefine issue.

